### PR TITLE
ci: fix building packages when dependend packages do not change

### DIFF
--- a/packages/debug/tsconfig.build.json
+++ b/packages/debug/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "inlineSources": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "composite": true
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/packages/di/tsconfig.build.json
+++ b/packages/di/tsconfig.build.json
@@ -6,5 +6,10 @@
   "include": ["src/**/*.ts"],
   "exclude": [
     "src/**/*.spec.ts"
+  ],
+  "references": [
+    {
+      "path": "../debug/tsconfig.build.json"
+    }
   ]
 }

--- a/packages/flux/tsconfig.build.json
+++ b/packages/flux/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "inlineSources": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "composite": true
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/packages/store/tsconfig.build.json
+++ b/packages/store/tsconfig.build.json
@@ -8,5 +8,8 @@
   "include": ["src/**/*.ts"],
   "exclude": [
     "src/**/*.spec.ts"
+  ],
+  "references": [
+    { "path": "../debug/tsconfig.build.json" }
   ]
 }


### PR DESCRIPTION
When a package changes but not its dependencies typescript will fail to build it because their defined path does not exists.

Using "references" and "composite" fixes it.