### PR TITLE
fix: publish step was failing after switch to hybrid packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,35 +48,6 @@ jobs:
         run: |
           yarn test:ci
 
-
-  Publish:
-    runs-on: ubuntu-latest
-    needs: Test_Lint
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          fetch-depth: 0
-
-      - name: Set git user
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          cache: 'yarn'
-          # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file,
-          # and set up auth to read in from env.NODE_AUTH_TOKEN.
-          # Default: ''
-          registry-url: 'https://registry.npmjs.org/'
-
-      - name: Install
-        run: yarn install --frozen-lockfile
-
       - name: Version_and_Deploy
         run: |
           yarn deploy:ci

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -37,7 +37,6 @@
     "build": "tsc -b tsconfig.build.json && tsc -b tsconfig.cjs.json",
     "build:ci": "yarn build",
     "test:ci": "jest --coverage --ci",
-    "prepack": "yarn build",
     "lint": "eslint ./src"
   }
 }

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -34,7 +34,6 @@
     "build": "tsc -b tsconfig.build.json && tsc -b tsconfig.cjs.json",
     "build:ci": "yarn build",
     "test:ci": "jest --coverage --ci",
-    "prepack": "yarn build",
     "lint": "eslint ./src"
   },
   "dependencies": {

--- a/packages/json-db/package.json
+++ b/packages/json-db/package.json
@@ -31,7 +31,6 @@
     "build": "tsc -b tsconfig.build.json && tsc -b tsconfig.cjs.json",
     "build:ci": "yarn build",
     "test:ci": "jest --coverage --ci",
-    "prepack": "yarn build",
     "lint": "eslint ./src"
   },
   "dependencies": {

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -31,7 +31,6 @@
     "build": "tsc -b tsconfig.build.json && tsc -b tsconfig.cjs.json",
     "build:ci": "yarn build",
     "test:ci": "jest --coverage --ci",
-    "prepack": "yarn build",
     "lint": "eslint ./src"
   },
   "devDependencies": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -41,7 +41,6 @@
     "build": "tsc -b tsconfig.build.json && tsc -b tsconfig.cjs.json",
     "build:ci": "yarn build",
     "test:ci": "jest --coverage --ci",
-    "prepack": "yarn build",
     "lint:ci": "eslint ./src"
   },
   "dependencies": {


### PR DESCRIPTION
Publish step was failing because the prepack script was executed by lerna in the package's folder.
This is failing for an unknown reason.
Running `yarn workspace package_name build` is working though.

To bypassa the issue the prepack lifecycles has been removed and the publish job has been moved to the Test_Lint job that has been renamed.

This way we can ensure that the packages are build before deploy.

This way we will always build all packages, whether before we were building only changed packages. This process is cheap and fast so we don't bother the trade off just yet.
